### PR TITLE
feat(resume): implement resume management APIs and fix security flaws

### DIFF
--- a/src/main/java/Cloudian/JobPortal/models/Resume.java
+++ b/src/main/java/Cloudian/JobPortal/models/Resume.java
@@ -1,7 +1,6 @@
 package Cloudian.JobPortal.models;
 
 import jakarta.persistence.*;
-import jdk.jfr.BooleanFlag;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -14,29 +13,37 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(
-
-)
+@Table(name = "resumes")
 public class Resume {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // thêm file name như yêu cầu:
+    @Column(nullable = false, name = "file_name")
+    private String fileName;
+
     @Column(nullable = false , name = "file_url")
     private String fileUrl;
+
     @CreationTimestamp
-    @Column(nullable = false , name = "uploaded_at")
+    @Column(nullable = false , name = "uploaded_at", updatable = false)
     private LocalDateTime uploadedAt;
-    @Column(nullable = false , name = "default_resume")
+
+    @Column(nullable = false , name = "is_default") // nên đổi thành is_default.
     @Builder.Default
-    private Boolean defaultResume = false;
+    private Boolean isDefault = false;
+
+    @Column(name = "deleted_at")
     @Builder.Default
-    LocalDateTime deleteAt = null;
+    LocalDateTime deletedAt = null; // đổi tên deleteAt -> deletedAt.
     //Foreign keys
+
     @OneToMany(mappedBy = "resume")
     @Builder.Default
     private List<JobApplication> jobApplicationList = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_seeker_id" , nullable = false )
     private JobSeekerProfile jobSeeker;
 

--- a/src/main/java/Cloudian/JobPortal/modules/minio/MinioService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/minio/MinioService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import java.util.UUID;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,16 +24,22 @@ public class MinioService {
     public String uploadFile(MultipartFile file) {
         try
         {
-            String fileName = file.getOriginalFilename();
+            String originalFilename = file.getOriginalFilename();
+            if (originalFilename == null) {
+                originalFilename = "unknown_file";
+            }
+            String cleanFileName = originalFilename.replaceAll("\\s+", "_");
+            String uniqueFileName = UUID.randomUUID().toString() + "_" + cleanFileName;
+
             minioClient.putObject(
                     PutObjectArgs.builder()
                             .bucket(bucketName)
-                            .object(fileName)
+                            .object(uniqueFileName)
                             .stream(file.getInputStream(), file.getSize(), -1)
                             .contentType(file.getContentType())
                             .build()
             );
-            return fileName;
+            return uniqueFileName;
         }
         catch (Exception e)
         {

--- a/src/main/java/Cloudian/JobPortal/modules/resume/ResumeController.java
+++ b/src/main/java/Cloudian/JobPortal/modules/resume/ResumeController.java
@@ -1,0 +1,51 @@
+package Cloudian.JobPortal.modules.resume;
+
+import Cloudian.JobPortal.modules.resume.dto.ResumeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+@RestController
+@RequestMapping("/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+    private final ResumeService resumeService;
+
+    // upload
+    @PreAuthorize("hasRole('SEEKER')")
+    @PostMapping("/upload")
+    public ResponseEntity<ResumeResponse> uploadResume(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "isDefault", required = false) Boolean isDefaultReq,
+            @RequestAttribute("userId") Long userId )
+    {
+        ResumeResponse response = resumeService.uploadResume(file, isDefaultReq, userId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // get
+    @PreAuthorize("hasRole('SEEKER')")
+    @GetMapping("/me")
+    public ResponseEntity<List<ResumeResponse>> getMyResumes(
+            @RequestAttribute("userId") Long userId )
+    {
+        List<ResumeResponse> responses = resumeService.getMyResumes(userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    // set
+    @PreAuthorize("hasRole('SEEKER')")
+    @PatchMapping("/{resumeId}/default")
+    public ResponseEntity<Void> setDefaultResume(
+            @PathVariable("resumeId") Long resumeId,
+            @RequestAttribute("userId") Long userId
+    ) {
+        resumeService.setDefaultResume(resumeId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/Cloudian/JobPortal/modules/resume/ResumeRepository.java
+++ b/src/main/java/Cloudian/JobPortal/modules/resume/ResumeRepository.java
@@ -1,0 +1,15 @@
+package Cloudian.JobPortal.modules.resume;
+
+import Cloudian.JobPortal.models.JobSeekerProfile;
+import Cloudian.JobPortal.models.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+    List<Resume> findAllByJobSeeker_User_Id(Long userId);
+    Optional<Resume> findByIdAndJobSeeker_User_Id(Long resumeId, Long userId);
+    Optional<Resume> findByJobSeeker_User_IdAndIsDefaultTrue(Long userId);
+}

--- a/src/main/java/Cloudian/JobPortal/modules/resume/ResumeService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/resume/ResumeService.java
@@ -1,0 +1,116 @@
+package Cloudian.JobPortal.modules.resume;
+
+import Cloudian.JobPortal.exceptions.custom.BadRequestException;
+import Cloudian.JobPortal.exceptions.custom.ResourceNotFoundException;
+import Cloudian.JobPortal.exceptions.custom.ForbiddenException;
+import Cloudian.JobPortal.models.JobSeekerProfile;
+import Cloudian.JobPortal.models.Resume;
+import Cloudian.JobPortal.modules.jobseeker.JobSeekerRepository;
+import Cloudian.JobPortal.modules.minio.MinioService;
+import Cloudian.JobPortal.modules.resume.dto.ResumeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+    private final ResumeRepository resumeRepository;
+    private final MinioService minioService;
+    private final JobSeekerRepository jobSeekerRepository;
+
+    //HELPER: Map Entity sang DTO
+    private ResumeResponse mapToResponse(Resume resume) {
+        return ResumeResponse.builder()
+                .id(resume.getId())
+                .fileName(resume.getFileName())
+                .fileUrl(resume.getFileUrl())
+                .defaultResume(resume.getIsDefault())
+                .uploadedAt(resume.getUploadedAt())
+                .build();
+    }
+
+    // upload / post
+    @Transactional
+    public ResumeResponse uploadResume(MultipartFile file, Boolean isDefaultReq, Long userId) {
+        if (file.isEmpty()) {
+            throw new BadRequestException("File cannot be empty");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null ||
+                (!contentType.equals("application/pdf") &&
+                !contentType.equals("application/vnd.openxmlformats-officedocument.wordprocessingml.document") &&
+                !contentType.equals("application/msword"))) {
+            throw new BadRequestException("Only PDF or DOCX files are allowed");
+        }
+
+        JobSeekerProfile profile = jobSeekerRepository.findByUserId(userId)
+                .orElseThrow(() -> new ForbiddenException("You must complete your Job Seeker profile before uploading a resume"));
+
+        List<Resume> existingResumes = resumeRepository.findAllByJobSeeker_User_Id(userId);
+        boolean isFirstResume = existingResumes.isEmpty();
+
+        // cv đầu tiên up lên mặc định làm default.
+        boolean setAsDefault = isFirstResume || (isDefaultReq != null && isDefaultReq);
+
+        if (setAsDefault && !isFirstResume) {
+            resumeRepository.findByJobSeeker_User_IdAndIsDefaultTrue(userId)
+                    .ifPresent(oldDefault -> {
+                        oldDefault.setIsDefault(false);
+                        resumeRepository.save(oldDefault);
+                    });
+        }
+
+        String minioObjectName = minioService.uploadFile(file);
+        String fileUrl = minioService.getFileUrl(minioObjectName);
+
+        Resume resume = Resume.builder()
+                .fileName(file.getOriginalFilename())
+                .fileUrl(fileUrl)
+                .isDefault(setAsDefault)
+                .jobSeeker(profile)
+                .build();
+
+        return mapToResponse(resumeRepository.save(resume));
+    }
+
+    // get
+    @Transactional(readOnly = true)
+    public List<ResumeResponse> getMyResumes(Long userId) {
+        return resumeRepository.findAllByJobSeeker_User_Id(userId)
+                .stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    // set
+    @Transactional
+    public void setDefaultResume(Long resumeId, Long userId) {
+        // 404
+        Resume targetResume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Resume not found"));
+
+        // 403
+        if (!targetResume.getJobSeeker().getUser().getId().equals(userId)) {
+            throw new ForbiddenException("You do not have permission to modify this resume");
+        }
+
+        if (targetResume.getIsDefault()) {
+            return;
+        }
+
+        resumeRepository.findByJobSeeker_User_IdAndIsDefaultTrue(userId)
+                .ifPresent(oldDefault -> {
+                    oldDefault.setIsDefault(false);
+                    resumeRepository.save(oldDefault);
+                });
+
+        targetResume.setIsDefault(true);
+        resumeRepository.save(targetResume);
+    }
+}

--- a/src/main/java/Cloudian/JobPortal/modules/resume/dto/ResumeResponse.java
+++ b/src/main/java/Cloudian/JobPortal/modules/resume/dto/ResumeResponse.java
@@ -1,0 +1,15 @@
+package Cloudian.JobPortal.modules.resume.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+public class ResumeResponse {
+    private Long id;
+    private String fileName;
+    private String fileUrl;
+    private Boolean defaultResume;
+    private LocalDateTime uploadedAt;
+}

--- a/src/main/java/Cloudian/JobPortal/security/JwtAuthenticationFilter.java
+++ b/src/main/java/Cloudian/JobPortal/security/JwtAuthenticationFilter.java
@@ -53,6 +53,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter
         System.out.println(authResult);
         if (!authResult) {
             filterChain.doFilter(request , response);
+            return;
         }
         System.out.println("Current auth before set: " +
                 SecurityContextHolder.getContext().getAuthentication());
@@ -69,6 +70,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter
             //Give it to Security Context
             SecurityContextHolder.getContext().setAuthentication(authObject);
             System.out.println("Role duoc set vao: " + userDetails.getAuthorities()); //Role da duoc set thanh cong roi
+
+            var user = userService.findUserByEmail(email);
+            if (user != null) {
+                request.setAttribute("userId", user.getId());
+            }
         }
 
         filterChain.doFilter(request , response);


### PR DESCRIPTION
- Sync Resume entity with ERD (add file_name, remove unmapped fields)
- Fix MinioService to prevent file overwrites by appending UUID
- Patch JwtAuthenticationFilter missing return statement and inject userId into request
- Implement POST /api/resumes/upload with auto-default logic
- Implement GET /api/resumes/me with row-level security
- Implement PATCH /api/resumes/{id}/default with transactional swap