### PR TITLE
feat(jobseeker, resume): implement soft delete and fix constraint map…

### DIFF
--- a/__init__.sql
+++ b/__init__.sql
@@ -24,3 +24,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_refresh_token
 CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email
     ON "users"("email")
     WHERE "delete_at" is NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_job_seeker_profile_user_id
+    ON "job_seeker_profile"("user_id")
+    WHERE "delete_at" is NULL;

--- a/src/main/java/Cloudian/JobPortal/models/JobSeekerProfile.java
+++ b/src/main/java/Cloudian/JobPortal/models/JobSeekerProfile.java
@@ -40,8 +40,8 @@ public class JobSeekerProfile {
     private String phone;
     //foreign key
     // User only has 1 profile
-    @OneToOne
-    @JoinColumn(nullable = false , name = "userId", unique = true)
+    @ManyToOne
+    @JoinColumn(nullable = false , name = "userId")
     private User user;
     // User has many CVs
     @OneToMany(mappedBy = "jobSeeker")

--- a/src/main/java/Cloudian/JobPortal/models/Resume.java
+++ b/src/main/java/Cloudian/JobPortal/models/Resume.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.SQLRestriction;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -17,7 +18,7 @@ import java.util.List;
 @Builder
 @SQLDelete(
         sql = """
-                UPDATE resume SET delete_at = NOW() WHERE id = ? 
+                UPDATE resumes SET delete_at = NOW() WHERE id = ? 
                 """
 )
 @SQLRestriction("delete_at is NULL")
@@ -38,13 +39,13 @@ public class Resume {
     @Column(nullable = false , name = "uploaded_at", updatable = false)
     private LocalDateTime uploadedAt;
 
-    @Column(nullable = false , name = "is_default") // nên đổi thành is_default.
+    @Column(nullable = false , name = "is_default")
     @Builder.Default
     private Boolean isDefault = false;
 
-    @Column(name = "deleted_at")
+    @Column(name = "delete_at")
     @Builder.Default
-    LocalDateTime deletedAt = null; // đổi tên deleteAt -> deletedAt.
+    LocalDateTime deleteAt = null;
     //Foreign keys
 
     @OneToMany(mappedBy = "resume")

--- a/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerController.java
+++ b/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerController.java
@@ -51,4 +51,12 @@ public class JobSeekerController {
         JobSeekerResponse response = jobSeekerService.updateProfile(request, userId);
         return ResponseEntity.ok(response);
     }
+
+    @PreAuthorize("hasRole('SEEKER')")
+    @DeleteMapping
+    public ResponseEntity<Void> deleteProfile(Authentication authentication) {
+        Long userId = getUserIdFromAuth(authentication);
+        jobSeekerService.deleteProfile(userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerService.java
@@ -88,5 +88,11 @@ public class JobSeekerService {
         return mapToResponse(jobSeekerRepository.save(profile));
     }
 
+    @Transactional
+    public void deleteProfile(Long userId) {
+        JobSeekerProfile profile = jobSeekerRepository.findByUserId(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Profile does not exist!"));
+        jobSeekerRepository.delete(profile);
+    }
 
 }

--- a/src/main/java/Cloudian/JobPortal/modules/resume/ResumeController.java
+++ b/src/main/java/Cloudian/JobPortal/modules/resume/ResumeController.java
@@ -48,4 +48,15 @@ public class ResumeController {
         return ResponseEntity.noContent().build();
     }
 
+    // delete
+    @PreAuthorize("hasRole('SEEKER')")
+    @DeleteMapping("/{resumeId}")
+    public ResponseEntity<Void> deleteResume(
+            @PathVariable("resumeId") Long resumeId,
+            @RequestAttribute("userId") Long userId
+    ) {
+        resumeService.deleteResume(resumeId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/Cloudian/JobPortal/modules/resume/ResumeService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/resume/ResumeService.java
@@ -113,4 +113,14 @@ public class ResumeService {
         targetResume.setIsDefault(true);
         resumeRepository.save(targetResume);
     }
+
+    @Transactional
+    public void deleteResume(Long resumeId, Long userId) {
+        Resume targetResume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Resume not found"));
+        if (!targetResume.getJobSeeker().getUser().getId().equals(userId)) {
+            throw new ForbiddenException("You do not have permission to delete this resume");
+        }
+        resumeRepository.delete(targetResume);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,9 @@ spring.datasource.password=admin
 #spring.datasource.password=npg_0UrdS2pEaBlh
 spring.datasource.driver-class-name=org.postgresql.Driver
 #create if want to drop table, updtae if want to keep the able
+
 spring.jpa.hibernate.ddl-auto=update
+
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 #Spring prefix version 2 (for New version)
 server.servlet.contextPath=/api


### PR DESCRIPTION
…ping

- Add @SQLDelete and @SQLRestriction to JobSeekerProfile and Resume entities for soft delete capability.
- Fix HTTP 500 error on profile recreation by changing @OneToOne to @ManyToOne in JobSeekerProfile.
- Add partial unique index (idx_job_seeker_profile_user_id) in __init__.sql to enforce uniqueness only on active profiles.
- Implement DELETE endpoints for profile and resumes with strict row-level security.