### PR TITLE
feat(api): add public endpoints and complete the message flow accordi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ CLAUDE.md
 .vscode/
 app.jar
 
+apidocs.md
 

--- a/src/main/java/Cloudian/JobPortal/configs/SecurityConfig.java
+++ b/src/main/java/Cloudian/JobPortal/configs/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig {
                                 .requestMatchers("/docs/**", "/docs").permitAll()
                                 .requestMatchers(HttpMethod.GET , "/jobpost", "/jobpost/**").permitAll()
                                 .requestMatchers(HttpMethod.GET , "/employers", "/employers/**").permitAll()
+                                .requestMatchers("/industries", "/industries/**").permitAll()
                                 .requestMatchers("/scalar/**").permitAll()
                                 .requestMatchers("/openapi.json", "/v3/api-docs/**").permitAll()
                                 .requestMatchers("/auth/verify").permitAll()

--- a/src/main/java/Cloudian/JobPortal/events/notification/NotificationEvent.java
+++ b/src/main/java/Cloudian/JobPortal/events/notification/NotificationEvent.java
@@ -23,4 +23,7 @@ public class NotificationEvent {
     private String targetUrl = "";
     @Builder.Default
     private List<Channel> channels = new ArrayList<>();
+
+    @Builder.Default
+    private String icon = "";
 }

--- a/src/main/java/Cloudian/JobPortal/models/Notification.java
+++ b/src/main/java/Cloudian/JobPortal/models/Notification.java
@@ -46,6 +46,9 @@ public class Notification {
     @Column(name = "target_url")
     private String targetUrl;
 
+    @Column(name = "icon")
+    private String icon;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/Cloudian/JobPortal/modules/employer/PublicEmployerController.java
+++ b/src/main/java/Cloudian/JobPortal/modules/employer/PublicEmployerController.java
@@ -5,6 +5,8 @@ import Cloudian.JobPortal.modules.base.dto.PageResponse;
 import Cloudian.JobPortal.modules.employer.dto.EmployerDetailResponse;
 import Cloudian.JobPortal.modules.employer.dto.EmployerFilterRequest;
 import Cloudian.JobPortal.modules.employer.dto.EmployerResponse;
+import Cloudian.JobPortal.modules.jobpost.JobPostService;
+import Cloudian.JobPortal.modules.jobpost.dto.JobPostResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class PublicEmployerController {
 
     private final PublicEmployerService publicEmployerService;
+    private final JobPostService jobPostService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<EmployerResponse>>> getAllEmployers(
@@ -31,5 +34,15 @@ public class PublicEmployerController {
     public ResponseEntity<EmployerDetailResponse> getEmployerDetail(@PathVariable Long id) {
         EmployerDetailResponse detail = publicEmployerService.getEmployerDetail(id);
         return ResponseEntity.ok(detail);
+    }
+
+    @GetMapping("/{employerId}/jobs")
+    public ResponseEntity<ApiResponse<PageResponse<JobPostResponse>>> getJobsByEmployer(
+            @PathVariable Long employerId,
+            @RequestParam(required = false, defaultValue = "0") Integer offset,
+            @RequestParam(required = false, defaultValue = "20") Integer limit
+    ) {
+        Page<JobPostResponse> page = jobPostService.getPublicJobsByEmployerId(employerId, limit, offset);
+        return ResponseEntity.ok(ApiResponse.ok(PageResponse.from(page)));
     }
 }

--- a/src/main/java/Cloudian/JobPortal/modules/employer/PublicEmployerService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/employer/PublicEmployerService.java
@@ -8,6 +8,8 @@ import Cloudian.JobPortal.modules.employer.dto.EmployerDetailResponse;
 import Cloudian.JobPortal.modules.employer.dto.EmployerFilterRequest;
 import Cloudian.JobPortal.modules.employer.dto.EmployerResponse;
 import Cloudian.JobPortal.modules.jobpost.JobPostRepository;
+import Cloudian.JobPortal.modules.jobpost.JobPostService;
+import Cloudian.JobPortal.modules.jobpost.dto.JobPostResponse;
 import Cloudian.JobPortal.modules.minio.MinioService;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;

--- a/src/main/java/Cloudian/JobPortal/modules/industry/PublicIndustryController.java
+++ b/src/main/java/Cloudian/JobPortal/modules/industry/PublicIndustryController.java
@@ -1,0 +1,26 @@
+package Cloudian.JobPortal.modules.industry;
+
+import Cloudian.JobPortal.modules.base.dto.ApiResponse;
+import Cloudian.JobPortal.modules.industry.dto.IndustryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/industries")
+@RequiredArgsConstructor
+public class PublicIndustryController {
+
+    private final IndustryService industryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<IndustryResponse>>> getAllIndustries() {
+        // Get all non-deleted industries with pagination: use large offset/limit to get all
+        var page = industryService.getAllIndustry(null, 0, 100);
+        return ResponseEntity.ok(ApiResponse.ok(page.getContent()));
+    }
+}

--- a/src/main/java/Cloudian/JobPortal/modules/jobpost/JobPostRepository.java
+++ b/src/main/java/Cloudian/JobPortal/modules/jobpost/JobPostRepository.java
@@ -36,4 +36,7 @@ public interface JobPostRepository extends JpaRepository<JobPost, Long>, JpaSpec
 
     @Query("SELECT COUNT(jp) FROM JobPost jp WHERE jp.employer.owner.id = :ownerId AND (jp.status = Cloudian.JobPortal.models.JobPostStatus.ACTIVE OR jp.status = Cloudian.JobPortal.models.JobPostStatus.OPEN)")
     long countActiveJobsByOwnerId(@Param("ownerId") Long ownerId);
+
+    @Query("SELECT jp FROM JobPost jp LEFT JOIN FETCH jp.employer WHERE jp.employer.id = :employerId AND (jp.status = 'OPEN' OR jp.status = 'ACTIVE') ORDER BY jp.createdAt DESC")
+    org.springframework.data.domain.Page<JobPost> findPublicJobsByEmployerId(@Param("employerId") Long employerId, org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/Cloudian/JobPortal/modules/jobpost/JobPostService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/jobpost/JobPostService.java
@@ -419,6 +419,13 @@ public class JobPostService {
         });
     }
 
+    @Transactional
+    public org.springframework.data.domain.Page<JobPostResponse> getPublicJobsByEmployerId(Long employerId, int limit, int offset) {
+        Pageable pageable = buildPageable(limit, offset);
+        return jobPostRepository.findPublicJobsByEmployerId(employerId, pageable)
+                .map(this::toResponse);
+    }
+
     @jakarta.transaction.Transactional
     public JobPostResponse updateJobPostStatus(Long id, Long userId, JobPostStatus newStatus) {
         JobPost jobPost = requireJobPost(id);

--- a/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerController.java
+++ b/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerController.java
@@ -51,10 +51,16 @@ public class JobSeekerController {
     @GetMapping("/discover")
     public ResponseEntity<ApiResponse<PageResponse<JobSeekerResponse>>> discoverProfiles(
             @RequestParam(required = false) String search,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) String skills,
+            @RequestParam(required = false) Integer experienceYears,
+            @RequestParam(required = false) String educationLevel,
+            @RequestParam(required = false) String jobLevel,
             @RequestParam(defaultValue = "20") Integer limit,
             @RequestParam(defaultValue = "0") Integer offset
     ) {
-        Page<JobSeekerResponse> response = jobSeekerService.discoverProfiles(search, limit, offset);
+        Page<JobSeekerResponse> response = jobSeekerService.discoverProfiles(search, keyword, location, skills, experienceYears, educationLevel, jobLevel, limit, offset);
         return ResponseEntity.ok(ApiResponse.ok(PageResponse.from(response)));
     }
     @PreAuthorize("hasRole('SEEKER')")

--- a/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/jobseeker/JobSeekerService.java
@@ -121,7 +121,7 @@ public class JobSeekerService {
     }
 
     @Transactional(readOnly = true)
-    public Page<JobSeekerResponse> discoverProfiles(String search, int limit, int offset) {
+    public Page<JobSeekerResponse> discoverProfiles(String search, String keyword, String location, String skills, Integer experienceYears, String educationLevel, String jobLevel, int limit, int offset) {
         if (limit < 1 || limit > 100) {
             throw new BadRequestException("Invalid limit");
         }
@@ -130,15 +130,55 @@ public class JobSeekerService {
         }
         Pageable pageable = PageRequest.of(offset / limit, limit);
         Specification<JobSeekerProfile> spec = (root, query, cb) -> {
-            if (search == null || search.isBlank()) {
-                return cb.conjunction();
+            List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
+
+            // Support the legacy 'search' param or the new 'keyword' param
+            String searchKeyword = (keyword != null && !keyword.isBlank()) ? keyword : search;
+            if (searchKeyword != null && !searchKeyword.isBlank()) {
+                String value = "%" + searchKeyword.trim().toLowerCase() + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("fullName")), value),
+                        cb.like(cb.lower(root.get("professionalTitle")), value)
+                ));
             }
-            String value = "%" + search.trim().toLowerCase() + "%";
-            return cb.or(
-                    cb.like(cb.lower(root.get("fullName")), value),
-                    cb.like(cb.lower(root.get("professionalTitle")), value),
-                    cb.like(cb.lower(root.get("address")), value)
-            );
+
+            if (location != null && !location.isBlank()) {
+                predicates.add(cb.like(
+                        cb.lower(root.get("address")),
+                        "%" + location.trim().toLowerCase() + "%"
+                ));
+            }
+
+            if (skills != null && !skills.isBlank()) {
+                predicates.add(cb.like(
+                        cb.lower(root.get("experienceSummary")),
+                        "%" + skills.trim().toLowerCase() + "%"
+                ));
+            }
+
+            if (experienceYears != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("id"), 0L)); // dummy - filter as text in experienceSummary
+                predicates.add(cb.like(
+                        cb.lower(root.get("experienceSummary")),
+                        "%" + experienceYears + "%"
+                ));
+            }
+
+            if (educationLevel != null && !educationLevel.isBlank()) {
+                predicates.add(cb.like(
+                        cb.lower(root.get("educationSummary")),
+                        "%" + educationLevel.trim().toLowerCase() + "%"
+                ));
+            }
+
+            if (jobLevel != null && !jobLevel.isBlank()) {
+                predicates.add(cb.like(
+                        cb.lower(root.get("professionalTitle")),
+                        "%" + jobLevel.trim().toLowerCase() + "%"
+                ));
+            }
+
+            return predicates.isEmpty() ? cb.conjunction() : cb.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
         };
         return jobSeekerRepository.findAll(spec, pageable).map(this::mapToResponse);
     }

--- a/src/main/java/Cloudian/JobPortal/modules/notification/NotificationController.java
+++ b/src/main/java/Cloudian/JobPortal/modules/notification/NotificationController.java
@@ -97,5 +97,24 @@ public class NotificationController {
         return ResponseEntity.ok(ApiResponse.ok("All notifications marked as read", null));
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteNotification(
+            @PathVariable Long id,
+            Authentication authentication
+    ) {
+        Long userId = getUserIdFromAuth(authentication);
+        notificationService.deleteNotification(id, userId);
+        return ResponseEntity.ok(ApiResponse.ok("Notification deleted successfully", null));
+    }
+
+    @DeleteMapping("/delete-all")
+    public ResponseEntity<ApiResponse<Void>> deleteAllNotifications(
+            Authentication authentication
+    ) {
+        Long userId = getUserIdFromAuth(authentication);
+        notificationService.deleteAllNotifications(userId);
+        return ResponseEntity.ok(ApiResponse.ok("All notifications deleted successfully", null));
+    }
+
     //firebase (POST), (GET_ALL - ADMIN ONLY) , (Call 2 duong link API cung 1 luc ?? -> Call in application -> Admin se
 }

--- a/src/main/java/Cloudian/JobPortal/modules/notification/NotificationRepository.java
+++ b/src/main/java/Cloudian/JobPortal/modules/notification/NotificationRepository.java
@@ -2,8 +2,12 @@ package Cloudian.JobPortal.modules.notification;
 
 import Cloudian.JobPortal.models.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -11,4 +15,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
     List<Notification> findByUserIdAndIsReadFalseOrderByCreatedAtDesc(Long userId);
     long countByUserIdAndIsReadFalse(Long userId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.deleteAt = :now WHERE n.user.id = :userId AND n.deleteAt IS NULL")
+    void softDeleteByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/Cloudian/JobPortal/modules/notification/NotificationService.java
+++ b/src/main/java/Cloudian/JobPortal/modules/notification/NotificationService.java
@@ -106,6 +106,22 @@ public class NotificationService {
         });
     }
     @Transactional
+    public void deleteNotification(Long id, Long userId) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Notification not found"));
+        // IDOR check: ensure the notification belongs to the current user
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new Cloudian.JobPortal.exceptions.custom.ForbiddenException("You do not have permission to delete this notification");
+        }
+        notificationRepository.delete(notification);
+    }
+
+    @Transactional
+    public void deleteAllNotifications(Long userId) {
+        notificationRepository.softDeleteByUserId(userId, java.time.LocalDateTime.now());
+    }
+
+    @Transactional
     public Notification createNotification(NotificationEvent notificationEvent)
     {
         User user = userRepository.findById(
@@ -113,11 +129,23 @@ public class NotificationService {
         ).orElseThrow(
                 () -> new NotFoundException("User not found")
         );
+        // Auto-assign icon based on notification type
+        String icon = notificationEvent.getIcon();
+        if ((icon == null || icon.isBlank()) && notificationEvent.getType() != null) {
+            icon = switch (notificationEvent.getType()) {
+                case CANDIDATE_APPLY -> "users";
+                case EMPLOYER_ACCOUNT_APPROVE -> "check-circle";
+                case ADMIN_RECEIVE_PAYMENT_PLAN -> "credit-card";
+                default -> "bell";
+            };
+        }
+
         Notification notification = Notification.builder()
                 .title(notificationEvent.getTitle())
                 .message(notificationEvent.getMessage())
                 .targetUrl(notificationEvent.getTargetUrl())
-                . user(user)
+                .icon(icon)
+                .user(user)
                 .build();
         notificationRepository.save(notification);
         NotificationChannel notificationChannelInApp = null;

--- a/src/main/java/Cloudian/JobPortal/modules/notification/dto/NotificationResponse.java
+++ b/src/main/java/Cloudian/JobPortal/modules/notification/dto/NotificationResponse.java
@@ -18,6 +18,7 @@ public class NotificationResponse {
     private String message;
     private Boolean isRead;
     private String targetUrl;
+    private String icon;
     private LocalDateTime createdAt;
 
     public static NotificationResponse from(Notification notification) {
@@ -27,6 +28,7 @@ public class NotificationResponse {
                 .message(notification.getMessage())
                 .isRead(notification.getIsRead())
                 .targetUrl(notification.getTargetUrl())
+                .icon(notification.getIcon())
                 .createdAt(notification.getCreatedAt())
                 .build();
     }


### PR DESCRIPTION
…ng to frontend control

- JobPost: Add public API 'GET /employers/{employerId}/jobs' to serve the company details page.
- Notification: Add API to delete single/delete all notifications with IDOR security block.
- Notification: Integrate 'icon' attribute automatically assigned by category (users, check-circle, credit-card).
- Industry: Create 'PublicIndustryController' to unlock the list of industries that do not require auth at 'GET /industries'.
- JobSeeker: Upgrade advanced candidate search filter (discover) with 6 dynamic parameters using JPA Specification.
- Security: Updated SecurityConfig to remove auth barrier for new public routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public industries catalog now accessible without authentication
  * New public endpoint to browse employer job listings
  * Enhanced job seeker discovery with advanced filtering options (location, skills, experience, education, job level)
  * Notifications now display icons automatically assigned based on notification type
  * Users can delete individual notifications or clear all notifications at once

* **Chores**
  * Updated gitignore for build artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->